### PR TITLE
HotFix(Image) : url remoteError

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -15,6 +15,7 @@ const nextConfig = {
       {
         protocol: "https",
         hostname: "dkvmrny1lb9jp.cloudfront.net",
+        pathname: "/**",
       },
     ],
   },


### PR DESCRIPTION
## PR 변경된 내용

- 이미지를 CloudFront URL에서 불러오지 못하는 오류 해결

## 추가 내용

## 참조


